### PR TITLE
Update the results to reflect what the zathras wrapper is looking for.

### DIFF
--- a/phoronix/run_phoronix.sh
+++ b/phoronix/run_phoronix.sh
@@ -293,5 +293,5 @@ $TOOLS_BIN/test_header_info --front_matter --results_file results_${sub_test}.cs
 #
 $run_dir/reduce_phoronix --sub_test $sub_test --out_file results_${sub_test}.csv --in_file /tmp/results_${test_name}_${to_tuned_setting}.out
 popd > /dev/null
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir "$RESULTSDIR ${pcpdir}" --test_name ph_${sub_test} --tuned_setting $to_tuned_setting --version none --user $to_user
+${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --copy_dir "$RESULTSDIR ${pcpdir}" --test_name phoronix_${sub_test} --tuned_setting $to_tuned_setting --version none --user $to_user
 exit $rtc


### PR DESCRIPTION
# Description
With the addition of subtests, we need to fix it so the results file matches what zathras is looking for.
Needs to be pushed with the updates to the zathras test_defs file for the phoronix subtests.  Pushing before those changes will result in Zathras not find the results file for stress-ng

# Before/After Comparison
Before change, zathras will not find the expected results file
After change, zathras willfind the expected results file

# Clerical Stuff
This closes #53 

Relates to JIRA: RPOPC-654