### PR TITLE
Fix cassandra sub test

### DIFF
--- a/phoronix/openmetrics_phoronix_cassandra.txt
+++ b/phoronix/openmetrics_phoronix_cassandra.txt
@@ -1,0 +1,4 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN

--- a/phoronix/reduce_phoronix
+++ b/phoronix/reduce_phoronix
@@ -238,7 +238,7 @@ reduce_phpbench()
 
 reduce_cassandra()
 {
-	reduce_3_fields "Test:Average,Deviation,Start_Date,End_Date" "Test:" "Average:" "Deviation:"
+	reduce_3_fields "Test,Average,Deviation,Start_Date,End_Date" "Test:" "Average:" "Deviation:"
 }
 
 reduce_openssl()

--- a/phoronix/results_schema_cassandra.py
+++ b/phoronix/results_schema_cassandra.py
@@ -1,0 +1,9 @@
+import pydantic
+import datetime
+
+class Phoronix_Results (pydantic.BaseModel):
+    Test: str
+    Average: int = pydantic.Field(gt=0)
+    Deviation: float = pydantic.Field(allow_inf_nan=False)
+    Start_Date: datetime.datetime
+    End_Date: datetime.datetime


### PR DESCRIPTION
# Description
Adds in the proper file for checking results and removes a ':' in the csv header

# Before/After Comparison
Before: Verification was failing as we did not have a file to check.
After:  Verification works properly and results are provided.

# Clerical Stuff
This closes #70 


Relates to JIRA: RPOPC-1020

Testing
Verified that the csv files are created and the export files are created properly (before they were not).
