### PR TITLE
Fix variable name.

### DIFF
--- a/phoronix/run_phoronix.sh
+++ b/phoronix/run_phoronix.sh
@@ -358,7 +358,7 @@ pcp_nginx()
 	do
 		connections=`echo $line | cut -d, -f 1`
 		rps=`echo $line | cut -d, -f 2`
-		results2pcp_multiple "connections:${connections},RPS:${RPS}"
+		results2pcp_multiple "connections:${connections},RPS:${rps}"
 	done < "$tfile"
 	reset_pcp_om
 	rm $tfile


### PR DESCRIPTION
# Description
Fixes a missed name variable.

# Before/After Comparison
Before: pcp did not contain the information for RPS
After:  pcp now contains the run results information in RPS.

# Clerical Stuff
This closes #67 
to close the issue out automatically.


Relates to JIRA: RPOPC-1247

Testing
Verified results appears as expected in pcp files.

